### PR TITLE
fix crash when clyde starts typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -788,7 +788,7 @@ declare namespace Eris {
     threadMembersUpdate: [channel: AnyThreadChannel, addedMembers: ThreadMember[], removedMembers: (ThreadMember | Uncached)[]];
     threadMemberUpdate: [channel: AnyThreadChannel, member: ThreadMember, oldMember: OldThreadMember];
     threadUpdate: [channel: AnyThreadChannel, oldChannel: OldThread | null];
-    typingStart: [channel: GuildTextableChannel | Uncached, user: User | Uncached, member: Member]
+    typingStart: [channel: GuildTextableChannel | Uncached, user: User | Uncached, member: Member | null]
     | [channel: PrivateChannel | Uncached, user: User | Uncached, member: null];
     unavailableGuildCreate: [guild: UnavailableGuild];
     unknown: [packet: RawPacket, id?: number];

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -839,7 +839,7 @@ class Shard extends EventEmitter {
             case "TYPING_START": {
                 let member = null;
                 const guild = this.client.guilds.get(packet.d.guild_id);
-                if(guild) {
+                if(guild && packet.d.member) {
                     packet.d.member.id = packet.d.user_id;
                     member = guild.members.update(packet.d.member, guild);
                 }
@@ -849,7 +849,7 @@ class Shard extends EventEmitter {
                     * @event Client#typingStart
                     * @prop {PrivateChannel | TextChannel | NewsChannel | Object} channel The text channel the user is typing in. If the channel is not cached, this will be an object with an `id` key. No other property is guaranteed
                     * @prop {User | Object} user The user. If the user is not cached, this will be an object with an `id` key. No other property is guaranteed
-                    * @prop {Member?} member The guild member, if typing in a guild channel, or `null`, if typing in a PrivateChannel
+                    * @prop {Member?} member The guild member, if typing in a guild channel, or `null`, if typing in a PrivateChannel or if the member is Clyde
                     */
                     this.emit("typingStart", this.client.getChannel(packet.d.channel_id) || {id: packet.d.channel_id}, this.client.users.get(packet.d.user_id) || {id: packet.d.user_id}, member);
                 }


### PR DESCRIPTION
This looks werid, just doing `| null` shouldn't be the fix, unless clyde doesn't give off a member type?
More testing is needed on what type Clyde is maybe? Still gonna merge #Yolo
I can't test as I don't have any servers with Clyde